### PR TITLE
Changed how the overall score is calculated.

### DIFF
--- a/src/services/jsonServer/apiBoardGameList.jsx
+++ b/src/services/jsonServer/apiBoardGameList.jsx
@@ -1,12 +1,11 @@
 import { BASE_API_URL } from '../apiConstants';
 
-function sumScore(score, rating) {
-  const scoreKeys = Object.keys(score);
-  const propertyCount = scoreKeys.length + 1;
-  let sum = rating;
-  for (const property of scoreKeys) {
-    sum += score[property];
-  }
+function sumScore(score) {
+  let sum = 0;
+  sum += score['difficulty'];
+  sum += score['learning_curve'];
+  sum += score['fun'];
+  const propertyCount = 3;
   return Number((sum / propertyCount).toFixed(2));
 }
 


### PR DESCRIPTION
We should use the scores calculated by the AI which
range from 1 to 10 as we instructed to do so.

The parameter rating is the BGG rating, which is not
calculated by the AI.

Likewise the fields for cost, duration and players should not be taken into account when calculating a rating.

Only use the fields: fun, learning_curve and difficulty.

Fixes Top 100 includes very high/low scores #35